### PR TITLE
Introduce `g:yamlfolds_use_yaml_fold_text` and support custom `foldtext`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Install using either [Pathogen][], [Vundle][], or similar.
 Vim script ID is [5559][].
 
 
+### Configuration
+
+```vim
+" Don't use `YamlFoldText()` of vim-yaml-folds.
+let g:yamlfolds_use_yaml_fold_text = v:false
+```
+
+
 ### Packaging
 
 Quick notes on packaging for vim.org, remember to update the version number:

--- a/after/ftplugin/yaml/folding.vim
+++ b/after/ftplugin/yaml/folding.vim
@@ -28,7 +28,10 @@ endfunction
 
 setlocal foldmethod=expr
 setlocal foldexpr=YamlFolds()
-setlocal foldtext=YamlFoldText()
+
+if get(g:, "yamlfolds_use_yaml_fold_text", v:true)
+  setlocal foldtext=YamlFoldText()
+endif
 
 let b:undo_ftplugin =
       \ exists('b:undo_ftplugin')


### PR DESCRIPTION
Hi. I added an variable `g:yamlfolds_use_yaml_fold_text`. If this variable is `v:false`, vim-yaml-folds doesn't set `foldtext=YamlFoldText()` so users can use their favorite `foldtext` function.

Fixes #3

Best regards.